### PR TITLE
Testing an `influx` query type

### DIFF
--- a/gxadmin
+++ b/gxadmin
@@ -609,6 +609,8 @@ elif [[ $1 == *"query" ]]; then
 		query_tsv "$qstr"
 	elif [[ $1 == "csvquery" ]]; then
 		query_csv "$qstr"
+	elif [[ $1 == "iquery" ]]; then
+		query_influx "$qstr" $2 fields
 	else
 		query "$qstr"
 	fi

--- a/gxadmin
+++ b/gxadmin
@@ -179,6 +179,21 @@ query_csv() {
 	psql -c "COPY ($1) to STDOUT with CSV DELIMITER ','"
 }
 
+
+function arr2awk() {
+    t=$(declare -p $1)
+    eval "declare -A t="${t#*=}
+    s=
+    for k in "${!t[@]}"; do
+        s+="$k=\"\$${t[$k]}\","
+    done
+    echo -n ${s:0:-2}
+}
+
+query_influx() {
+	psql -c "COPY ($1) to STDOUT with CSV DELIMITER E','" | awk -F, "{print \"${2} $(arr2awk $3)}"
+}
+
 if (( $# == 0 )); then
 	usage safe
 fi
@@ -374,6 +389,7 @@ elif [[ $1 == "migrate-tool-install-to-sqlite" ]]; then ## migrate-tool-install-
 
 elif [[ $1 == *"query" ]]; then
 	if [[ $2 == "latest-users" ]]; then ## {,csv,tsv}query   latest-users: 40 recently registered users
+		declare -A fields=( [email]=5 [username]=4 [disk_usage]=3 [create_time]=2 [id]=1 )
 		qstr="
 			SELECT id, create_time, pg_size_pretty(disk_usage), username, email
 			FROM galaxy_user
@@ -572,6 +588,17 @@ elif [[ $1 == *"query" ]]; then
 				JOIN dataset d
 					ON hda.dataset_id = d.id
 			WHERE j.id = $3
+		"
+	elif [[ $2 == "jobs-queued" ]]; then ## {,csv,tsv}query   jobs-queued
+		declare -A fields=( [internal]=2 [external]=1 )
+		qstr="
+		SELECT
+			sum(CASE WHEN job_runner_external_id IS NOT null THEN 1 ELSE 0 END) as external,
+			sum(CASE WHEN job_runner_external_id IS null THEN 1 ELSE 0 END) as internal
+		FROM
+			job
+		WHERE
+			state = 'queued'
 		"
 	else
 		error "Unknown query"


### PR DESCRIPTION
Since we can so easily to csv/tsv, why not add support for influx format for stats? Thoughts @natefoo?

Notes:

1. not every query will be perfectly appropriate to run in influx style but who are we to judge, maybe someone wants some different kinds of graphs
2. Would probably need to find a way to support some columns being mapped to tags rather than values (and to do the appropriate expansion for that, e.g. a job-states need to return N lines of text for each counted job state.)