### PR TITLE
Slurp group queries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please make PRs to the `dev` branch, `master` will be reserved for release-ready versions.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Command | Description
 [`query queue-time`](docs/README.query.md#query-queue-time) | The average/95%/99% a specific tool spends in queue state.
 [`query recent-jobs`](docs/README.query.md#query-recent-jobs) | Jobs run in the past <hours> (in any state)
 [`query runtime-per-user`](docs/README.query.md#query-runtime-per-user) | computation time of user (by email)
+[`query server-groups-allocated-cpu`](docs/README.query.md#query-server-groups-allocated-cpu) | Retrieve an approximation of the CPU allocation for groups
 [`query server-groups-disk-usage`](docs/README.query.md#query-server-groups-disk-usage) | Retrieve an approximation of the disk usage for groups
 [`query tool-available-metrics`](docs/README.query.md#query-tool-available-metrics) | list all available metrics for a given tool
 [`query tool-errors`](docs/README.query.md#query-tool-errors) | Summarize percent of tool runs in error over the past weeks for all tools that have failed (most popular tools first)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Command | Description
 [`query queue-time`](docs/README.query.md#query-queue-time) | The average/95%/99% a specific tool spends in queue state.
 [`query recent-jobs`](docs/README.query.md#query-recent-jobs) | Jobs run in the past <hours> (in any state)
 [`query runtime-per-user`](docs/README.query.md#query-runtime-per-user) | computation time of user (by email)
+[`query server-groups-disk-usage`](docs/README.query.md#query-server-groups-disk-usage) | Retrieve an approximation of the disk usage for groups
 [`query tool-available-metrics`](docs/README.query.md#query-tool-available-metrics) | list all available metrics for a given tool
 [`query tool-errors`](docs/README.query.md#query-tool-errors) | Summarize percent of tool runs in error over the past weeks for all tools that have failed (most popular tools first)
 [`query tool-last-used-date`](docs/README.query.md#query-tool-last-used-date) | When was the most recent invocation of every tool

--- a/docs/README.query.md
+++ b/docs/README.query.md
@@ -39,6 +39,7 @@ Command | Description
 [`query queue-time`](#query-queue-time) | The average/95%/99% a specific tool spends in queue state.
 [`query recent-jobs`](#query-recent-jobs) | Jobs run in the past <hours> (in any state)
 [`query runtime-per-user`](#query-runtime-per-user) | computation time of user (by email)
+[`query server-groups-disk-usage`](#query-server-groups-disk-usage) | Retrieve an approximation of the disk usage for groups
 [`query tool-available-metrics`](#query-tool-available-metrics) | list all available metrics for a given tool
 [`query tool-errors`](#query-tool-errors) | Summarize percent of tool runs in error over the past weeks for all tools that have failed (most popular tools first)
 [`query tool-last-used-date`](#query-tool-last-used-date) | When was the most recent invocation of every tool
@@ -777,6 +778,17 @@ query runtime-per-user -  computation time of user (by email)
        sum
     ----------
      14:07:39
+
+
+### query server-groups-disk-usage
+
+**NAME**
+
+query server-groups-disk-usage -  Retrieve an approximation of the disk usage for groups
+
+**SYNOPSIS**
+
+`gxadmin query server-groups-disk-usage [YYYY-MM-DD] [=, <=, >= operators]`
 
 
 ### query tool-available-metrics

--- a/docs/README.query.md
+++ b/docs/README.query.md
@@ -39,6 +39,7 @@ Command | Description
 [`query queue-time`](#query-queue-time) | The average/95%/99% a specific tool spends in queue state.
 [`query recent-jobs`](#query-recent-jobs) | Jobs run in the past <hours> (in any state)
 [`query runtime-per-user`](#query-runtime-per-user) | computation time of user (by email)
+[`query server-groups-allocated-cpu`](#query-server-groups-allocated-cpu) | Retrieve an approximation of the CPU allocation for groups
 [`query server-groups-disk-usage`](#query-server-groups-disk-usage) | Retrieve an approximation of the disk usage for groups
 [`query tool-available-metrics`](#query-tool-available-metrics) | list all available metrics for a given tool
 [`query tool-errors`](#query-tool-errors) | Summarize percent of tool runs in error over the past weeks for all tools that have failed (most popular tools first)
@@ -778,6 +779,17 @@ query runtime-per-user -  computation time of user (by email)
        sum
     ----------
      14:07:39
+
+
+### query server-groups-allocated-cpu
+
+**NAME**
+
+query server-groups-allocated-cpu -  Retrieve an approximation of the CPU allocation for groups
+
+**SYNOPSIS**
+
+`gxadmin query server-groups-allocated-cpu [YYYY-MM-DD] [=, <=, >= operators]`
 
 
 ### query server-groups-disk-usage

--- a/gxadmin
+++ b/gxadmin
@@ -2179,7 +2179,7 @@ query_group-cpu-seconds() { ## [group]: Retrieve an approximation of the CPU tim
 			job_metric_numeric b,
 			galaxy_group,
 			job
-			FULL OUTER JOIN user_group_association ON job.user_id = user_group_association.id
+			FULL OUTER JOIN user_group_association ON job.user_id = user_group_association.user_id
 		WHERE
 			b.job_id = a.job_id
 			AND a.job_id = job.id
@@ -2778,6 +2778,44 @@ query_server-workflow-invocations() {
 		${date_filter}
 		GROUP BY
 			scheduler, handler
+	EOF
+}
+
+query_server-groups-disk-usage() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an approximation of the disk usage for groups
+	handle_help "$@" <<-EOF
+	EOF
+
+	op="="
+	if (( $# > 1 )); then
+		op="$2"
+	fi
+
+	date_filter=""
+	if (( $# > 0 )); then
+		date_filter="AND date_trunc('day', dataset.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	fi
+
+	groupname=$(gdpr_safe galaxy_group.name group_name 'Anonymous')
+
+	fields="storage_usage=1"
+	tags="group_name=0"
+
+	read -r -d '' QUERY <<-EOF
+		SELECT $groupname,
+			sum(total_size) as "storage_usage"
+		FROM dataset,
+			galaxy_group,
+			user_group_association,
+			history_dataset_association,
+			history
+		WHERE NOT dataset.purged
+			AND dataset.id = history_dataset_association.dataset_id
+			AND dataset.total_size > 0
+			AND history_dataset_association.history_id = history.id
+			AND history.user_id = user_group_association.id
+			AND user_group_association.group_id = galaxy_group.id
+			$date_filter
+		GROUP BY galaxy_group.name
 	EOF
 }
 

--- a/gxadmin
+++ b/gxadmin
@@ -2819,6 +2819,43 @@ query_server-groups-disk-usage() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrie
 	EOF
 }
 
+query_server-groups-allocated-cpu() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an approximation of the CPU allocation for groups
+	handle_help "$@" <<-EOF
+	EOF
+
+	op="="
+	if (( $# > 1 )); then
+		op="$2"
+	fi
+
+	date_filter=""
+	if (( $# > 0 )); then
+		date_filter="AND date_trunc('day', dataset.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	fi
+
+	groupname=$(gdpr_safe galaxy_group.name group_name 'Anonymous')
+
+	fields="cpu_seconds=1"
+	tags="group_name=0"
+
+	read -r -d '' QUERY <<-EOF
+		SELECT $groupname,
+			round(sum(a.metric_value * b.metric_value), 2) AS cpu_seconds
+		FROM job_metric_numeric AS a,
+			job_metric_numeric AS b,
+			job,
+			galaxy_group,
+			user_group_association
+		WHERE b.job_id = a.job_id
+			AND a.metric_name = 'runtime_seconds'
+			AND b.metric_name = 'galaxy_slots'
+			AND job.user_id = user_group_association.id
+			AND user_group_association.group_id = galaxy_group.id
+			$date_filter
+		GROUP BY galaxy_group.name
+	EOF
+}
+
 query_workflow-invocation-status() { ## : Report on how many workflows are in new state by handler
 	handle_help "$@" <<-EOF
 		Really only intended to be used in influx queries.

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -1090,7 +1090,7 @@ query_group-cpu-seconds() { ## [group]: Retrieve an approximation of the CPU tim
 			job_metric_numeric b,
 			galaxy_group,
 			job
-			FULL OUTER JOIN user_group_association ON job.user_id = user_group_association.id
+			FULL OUTER JOIN user_group_association ON job.user_id = user_group_association.user_id
 		WHERE
 			b.job_id = a.job_id
 			AND a.job_id = job.id
@@ -1689,6 +1689,44 @@ query_server-workflow-invocations() {
 		${date_filter}
 		GROUP BY
 			scheduler, handler
+	EOF
+}
+
+query_server-groups-disk-usage() { ## [YYYY-MM-DD] [=, <=, >= operators]: Retrieve an approximation of the disk usage for groups
+	handle_help "$@" <<-EOF
+	EOF
+
+	op="="
+	if (( $# > 1 )); then
+		op="$2"
+	fi
+
+	date_filter=""
+	if (( $# > 0 )); then
+		date_filter="AND date_trunc('day', dataset.create_time AT TIME ZONE 'UTC') $op '$1'::date"
+	fi
+
+	groupname=$(gdpr_safe galaxy_group.name group_name 'Anonymous')
+
+	fields="storage_usage=1"
+	tags="group_name=0"
+
+	read -r -d '' QUERY <<-EOF
+		SELECT $groupname,
+			sum(total_size) as "storage_usage"
+		FROM dataset,
+			galaxy_group,
+			user_group_association,
+			history_dataset_association,
+			history
+		WHERE NOT dataset.purged
+			AND dataset.id = history_dataset_association.dataset_id
+			AND dataset.total_size > 0
+			AND history_dataset_association.history_id = history.id
+			AND history.user_id = user_group_association.id
+			AND user_group_association.group_id = galaxy_group.id
+			$date_filter
+		GROUP BY galaxy_group.name
 	EOF
 }
 


### PR DESCRIPTION
Add queries to get more detailed information about groups when running the metadata slurping of gxadmin. They will allow to monitor the disk usage for a specific group as well as the allocated CPU seconds. This information can be displayed GDPR compliant as well.