### PR TITLE
Fix incorrect sum for upload-gb-in-past-hour when no data

### DIFF
--- a/gxadmin
+++ b/gxadmin
@@ -3949,7 +3949,7 @@ query_upload-gb-in-past-hour() { ## [hours|1]: Sum in bytes of files uploaded in
 
 	read -r -d '' QUERY <<-EOF
 		SELECT
-			sum(coalesce(dataset.total_size, coalesce(dataset.file_size, 0))),
+			coalesce(sum(coalesce(dataset.total_size, coalesce(dataset.file_size, 0))), 0),
 			$hours as hours
 		FROM
 			job

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -2724,7 +2724,7 @@ query_upload-gb-in-past-hour() { ## [hours|1]: Sum in bytes of files uploaded in
 
 	read -r -d '' QUERY <<-EOF
 		SELECT
-			sum(coalesce(dataset.total_size, coalesce(dataset.file_size, 0))),
+			coalesce(sum(coalesce(dataset.total_size, coalesce(dataset.file_size, 0))), 0),
 			$hours as hours
 		FROM
 			job


### PR DESCRIPTION
When upload-gb-in-past-hour in past hour is invoked as follows, it generates the following results when there's no data.
```
$ gxadmin query upload-gb-in-past-hour
 sum | hours 
-----+-------
     |     1

$ gxadmin iquery upload-gb-in-past-hour
upload-gb-in-past-hour,hours=1 count=
```
which results in an incorrect measurement value of null. This PR forces the count to be zero when no data is present.