### PR TITLE
avoid username duplications

### DIFF
--- a/gxadmin
+++ b/gxadmin
@@ -1745,7 +1745,7 @@ query_training-members() { ## <tr_id>: List users in a specific training
 	username=$(gdpr_safe galaxy_user.username username)
 
 	read -r -d '' QUERY <<-EOF
-			SELECT
+			SELECT DISTINCT ON ($username) 
 				$username,
 				date_trunc('second', user_group_association.create_time AT TIME ZONE 'UTC') as joined
 			FROM galaxy_user, user_group_association, galaxy_group


### PR DESCRIPTION
Ensure the query doesn't return the same username more than one time as it is happening now
```
root@sn04:~$ gxadmin tsvquery training-members galaxy-hts-2019
xxxx    2019-09-27 12:04:02+02
yyyyy    2019-09-27 11:56:21+02
fff    2019-09-27 11:44:45+02
ffff    2019-09-27 11:32:23+02
mmmmm    2019-09-27 11:12:12+02
ddddd    2019-09-27 11:03:54+02
aaaa    2019-09-27 11:03:26+02
felix    2019-09-26 23:32:20+02
felix    2019-09-26 22:28:51+02
felix    2019-09-26 20:38:58+02
felix    2019-09-26 16:44:48+02
felix    2019-09-26 16:44:34+02
ssssssssss    2019-09-26 15:16:09+02
sssssss   2019-09-26 15:02:33+02
...
```