### PR TITLE
Add mutate to fix 2nd account with OIDC login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added:
 	- mutate fail-wfi
+	- mutate oidc-by-emails, mutate users affected by https://github.com/galaxyproject/galaxy/issues/9981
 
 # 18
 

--- a/parts/21-mutate.sh
+++ b/parts/21-mutate.sh
@@ -518,3 +518,24 @@ mutate_fail-wfi() { ## <wf-invocation-d> [--commit]: Sets a workflow invocation 
 	commit=$(should_commit "$2")
 	QUERY="BEGIN TRANSACTION; $QUERY; $commit"
 }
+
+mutate_oidc-by-emails() { ## <email_from> <email_to> [--commit]: Reassign OIDC account between users.
+	handle_help "$@" <<-EOF
+		Workaround for users creating a new account by clicking the OIDC button, with case mismatching between existing accounts. 
+		Please note that this function is case-sensitive. Fixes https://github.com/galaxyproject/galaxy/issues/9981.
+	EOF
+
+	assert_count_ge $# 2 "Must supply an email_from and an email_to";
+
+	read -r -d '' QUERY <<-EOF
+		UPDATE oidc_user_authnz_tokens
+		SET user_id=correctuser.id
+		FROM (
+			SELECT id FROM galaxy_user WHERE email='$2'
+		) AS correctuser
+		WHERE user_id = (SELECT id FROM galaxy_user WHERE email='$1')
+	EOF
+
+	commit=$(should_commit "$3")
+	QUERY="BEGIN TRANSACTION; $QUERY; $commit"
+}


### PR DESCRIPTION
Allows easier migration between Galaxy accounts in case of a 'wrongful' OIDC account creation (https://github.com/galaxyproject/galaxy/issues/9981)