### PR TITLE
Change influx measurement name for `iquery queue --by ...`

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -334,7 +334,8 @@ query_queue() { ## [--by (tool|destination|user)]: Brief overview of currently r
 			title="destination"
 			query_name="queue_by_destination"
 		elif [[ "$2" == "tool" ]]; then
-			true # nothing needed
+			query_name="queue_by_tool"
+			# nothing else needed
 		else
 			error "Unknown attribute"
 			exit 1

--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -327,10 +327,12 @@ query_queue() { ## [--by (tool|destination|user)]: Brief overview of currently r
 			tags="user_id=0;state=1"
 			column="user_id"
 			title="user"
+			query_name="queue_by_user"
 		elif [[ "$2" == "destination" ]]; then
 			tags="destination_id=0;state=1"
 			column="destination_id"
 			title="destination"
+			query_name="queue_by_destination"
 		elif [[ "$2" == "tool" ]]; then
 			true # nothing needed
 		else


### PR DESCRIPTION
Otherwise they all have the measurement `queue`.

I also made it so that if you don't pass `--by` the measurement remains `queue` but if you explicitly pass `--by tool` (the default if you don't pass `--by`) it sets the measurement to `queue_by_tool`. Not sure how you (@hexylena) feel about this.