### PR TITLE
Add update time to queue-overview query

### DIFF
--- a/parts/22-query.sh
+++ b/parts/22-query.sh
@@ -385,6 +385,7 @@ query_queue-overview() { ##? [--short-tool-id]: View used mostly for monitoring
 				COALESCE(destination_id, 'unknown')::TEXT AS destination_id,
 				COALESCE(handler, 'unknown')::TEXT AS handler,
 				state::TEXT,
+				update_time AT TIME ZONE 'UTC' AS updated,
 				COALESCE(job_runner_name, 'unknown')::TEXT AS job_runner_name,
 				count(*) AS count,
 				$user_id::TEXT AS user_id


### PR DESCRIPTION
Adds update time to the overview query to help identify jobs which are stuck in a certain state.